### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # RatingBar
 
-##[中文版][3]
-##a custom Ratingbar in android
+## [中文版][3]
+## a custom Ratingbar in android
 ![image](https://github.com/hedge-hog/RatingBar/blob/master/ic_demo.png)
 
 # How to use
-###Android Studio：
+### Android Studio：
 ```groovy
     dependencies {
         compile 'com.hedgehog.ratingbar:app:1.1.2'
     }
 ```
-###1，In xml
+### 1，In xml
 
     <com.hedgehog.ratingbar.RatingBar
         android:id="@+id/ratingbar"
@@ -31,7 +31,7 @@
         hedgehog:starImagePadding="20dp"/>
       
 
-###method statement
+### method statement
 | method|    action | 
 | :-------- | :--------|
 |hedgehog:clickable="true"   |Could you click|
@@ -43,12 +43,12 @@
 |hedgehog:starImageHeight="90dp"|the height of the stars|
 |hedgehog:starImageWidth="70dp"|the width of the star|
 |hedgehog:starImagePadding="20dp"|the padding of the star|
-###Don't forget to namespace
+### Don't forget to namespace
 
 ```
 xmlns:hedgehog="http://schemas.android.com/apk/res-auto"
 ```
-###2，In Java code
+### 2，In Java code
 
     ```
        RatingBar mRatingBar = (RatingBar) findViewById(R.id.ratingbar);
@@ -73,7 +73,7 @@ xmlns:hedgehog="http://schemas.android.com/apk/res-auto"
 
         ```
 
-###method statement
+### method statement
 | method      |    action | 
 | :-------- | :--------:|
 |mRatingBar.setStarCount(5);|The total number of stars|
@@ -85,15 +85,15 @@ xmlns:hedgehog="http://schemas.android.com/apk/res-auto"
 |mRatingBar.setImagePadding(35);|the padding of the stars|
 
 
-#about
+# about
 Because the project need this function, but the android itself on the propagation of the Ratingbar support is very bad, so intend to write their own a, because my ability is limited, a lot of the function is not perfect, if you have a better solution, welcome to tell me, thank you
 
-#unsolved
+# unsolved
 - You can set the padding between the stars，But because the Ratingbar is rewriting Imageview, so distance setting still need to fine tune
 - You can set up half a star，but this method is very bad，Using this method is not recommended，Look at the code if you want to know the details，Please let me know if you have a good solution
 
 
-#Thank
+# Thank
 Thanks the  [Android_custom_ratingbarview][1] You can look at it  
 Thanks[lingguohui][2]for his code
 
@@ -101,7 +101,7 @@ Thanks[lingguohui][2]for his code
 [2]:https://github.com/lingguohui
 [3]:https://github.com/hedge-hog/RatingBar/blob/master/README_CH.md
 
-#License
+# License
 ```
 Copyright 2015 hedge_hog
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -1,14 +1,14 @@
 # RatingBar
-##android中一个评分的控件
+## android中一个评分的控件
 ![image](https://github.com/hedge-hog/RatingBar/blob/master/ic_demo.png)
 # 如何使用
-###Android Studio下：
+### Android Studio下：
 ```
     dependencies {
         compile 'com.hedgehog.ratingbar:app:1.1.2'
     }
 ```
-###1，在XML中
+### 1，在XML中
 ```
    <com.hedgehog.ratingbar.RatingBar
         android:id="@+id/ratingbar"
@@ -29,7 +29,7 @@
 
 ```
 
-###方法说明
+### 方法说明
 | 方法      |    用途 |
 | :-------- | :--------:|
 |hedgehog:clickable="true"   |是否可点击|
@@ -42,11 +42,11 @@
 |hedgehog:starImageHeight="90dp"|N颗星星的高度|
 |hedgehog:starImageWidth="70dp"|N颗星星的宽度|
 |hedgehog:starImagePadding="20dp"|星星之间的间距|
-###注意：别忘了命名空间
+### 注意：别忘了命名空间
 ```
 xmlns:hedgehog="http://schemas.android.com/apk/res-auto"
 ```
-###2，在java代码中
+### 2，在java代码中
 ```
 RatingBar mRatingBar = (RatingBar) findViewById(R.id.ratingbar);
 mRatingBar.setStarEmptyDrawable(getResources().getDrawable(R.mipmap.star_empty));
@@ -70,7 +70,7 @@ mRatingBar.setOnRatingChangeListener(
 
 ```
 
-###方法说明
+### 方法说明
 | 方法      |    用途 |
 | :-------- | :--------:|
 |mRatingBar.setStarCount(5);|星星的总数|
@@ -81,55 +81,55 @@ mRatingBar.setOnRatingChangeListener(
 |mRatingBar.setStarImageHeight(60f);|N颗星星的高度|
 |mRatingBar.setImagePadding(35);|星星之间的间距|
 
-##1.1.2
+## 1.1.2
 - 对于只需要展示，不需要做任何操作的使用者，新增了直接在xml文件中设置star的总数，以及填充的数量。不过设置方法略显麻烦，请看下面
 >hedgehog:starNum="3"可以设置填充的星星的数量，当xml中设置starNum的时,starCount的数量需要重新计算，starCount=星星总数-starNum，参考下图。
 
 ![image](https://github.com/hedge-hog/RatingBar/blob/master/ic_starnum.png)
 
-##1.1.1
+## 1.1.1
 - 修改了在xml中设置clickable=false失效的问题
 
-##1.1.0
+## 1.1.0
 - 修改了半颗星星不能设置的问题，不过不建议使用。
 - 增加了可以自由设置星星间的间距及大小
 
-##1.0.4
+## 1.0.4
 - 解决了图标冲突的问题
 
 
-##1.0.3
+## 1.0.3
 - 兼容到API9
 
-##1.0.2
+## 1.0.2
 - 从happyhou处meger半颗星的功能
 
-##1.0.1
+## 1.0.1
 - bug fix
 
-##1.0.0
+## 1.0.0
 - init project
 
 
 
-##未解决的
+## 未解决的
 - **半颗星星的功能目前不是很好，不建议使用，具体的可以去看看代码。我这么写出来，只是做一个参考**
 - 星星之间的间距可以设置，不过由于是重写的Imageview，所以间距的设置还需要自己微调。
 
 
-##关于
+## 关于
 因为项目中需要这个功能，但android本身对Ratingbar的扩展支持的很不好，所以打算自己写一个，能力有限，很多功能不完善，如果你有更好的解决方案，欢迎告诉我，谢谢！
 
 
 
-###感谢
+### 感谢
 感谢[Android_custom_ratingbarview][1]，最开始就参考的是这个项目。
 感谢[lingguohui][2]，半颗星的功能就是这位同学想到的。
 
 [1]:https://github.com/JackWong025/Android_custom_ratingbarview
 [2]:https://github.com/lingguohui
 
-#License
+# License
 ```
 Copyright 2015 hedge_hog
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
